### PR TITLE
Fix issue with DMT PIP/CIP probe particle spanning two image frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ Imagefile*
 base*
 *sublime*
 spifpy.egg-info/**
+nrc_spifpy.egg-info/
 venv/**

--- a/nrc_spifpy/input/dmt_mono_file.py
+++ b/nrc_spifpy/input/dmt_mono_file.py
@@ -95,12 +95,12 @@ class DMTMonoFile(DMTBinaryFile):
         record = data['data']
         try:
             record_next = self.data[frame+1]['data']
-            Next_record_Flag = True
+            next_record_exists = True
             record = numpy.concatenate((record, record_next))
         except Exception as e:
             # raise e
             # pass
-            Next_record_Flag = False
+            next_record_exists = False
 
         i = 0
         frame_decomp = []
@@ -125,10 +125,10 @@ class DMTMonoFile(DMTBinaryFile):
 
             # Note: The condition "i > 4096 + 8" ensures that we read the first full sequence of "7, [170] * 8"
             # from the next frame. Or, the first partical of the next frame will be missed.
-            if Next_record_Flag and (len(frame_decomp) > 16) and \
+            if next_record_exists and (len(frame_decomp) > 16) and \
                (frame_decomp[-8:] == self.syncword).all() and (i > 4096 + 8): 
                 break  
-            if (not Next_record_Flag) and (i >= 4096):
+            if (not next_record_exists) and (i >= 4096):
                 break
 
         date = datetime.datetime(data['year'],

--- a/nrc_spifpy/input/input_utils.py
+++ b/nrc_spifpy/input/input_utils.py
@@ -47,7 +47,7 @@ def read_sea_image_data(filename, file_dtype, typ, inst_name=None):
 
 def read_sea_tas(filename, typ, resolution):
 
-    if typ is '2dc':
+    if typ == '2dc':
         tas_tag = 6  # 2D Mono TAS Factors
 
     time, dset = read_sea_file(filename, tas_tag)

--- a/nrc_spifpy/input/spec_file.py
+++ b/nrc_spifpy/input/spec_file.py
@@ -418,11 +418,11 @@ class SPECFile(BinaryFile):
         record = data['data']
         try:
             record_next = self.data[frame+1]['data']
-            Next_record_Flag = True
+            next_record_exists = True
         except Exception as e:
             # raise e
             # pass
-            Next_record_Flag = False
+            next_record_exists = False
         # print(record)
 
         # Define Images objects for current frame
@@ -554,7 +554,7 @@ class SPECFile(BinaryFile):
                     reach_record_end = True
 
                 if reach_record_end:
-                    if Next_record_Flag:
+                    if next_record_exists:
                         record_pad = numpy.concatenate((record, record_next))
                     else:
                         break
@@ -677,7 +677,7 @@ class SPECFile(BinaryFile):
                 '''
                 if i + hk_length > len(record): # reach the end of record
                     reach_record_end = True
-                    if Next_record_Flag:
+                    if next_record_exists:
                         record_pad = numpy.concatenate((record, record_next))
                     elif i + 50 < len(record):
                         record_pad = record

--- a/nrc_spifpy/input/spec_file.py
+++ b/nrc_spifpy/input/spec_file.py
@@ -227,6 +227,11 @@ class SPECFile(BinaryFile):
             buffer_indx = spiffile.instgrps[inst_group]['core']['buffer_index'][:]
             try:
                 tas = spiffile.instgrps[inst_group]['core']['tas'][:]
+
+                # Fill NaN using numpy's interp, Yongjie Huang, 2024-08-17.
+                mask = numpy.isnan(tas)
+                tas[mask] = numpy.interp(numpy.flatnonzero(mask), numpy.flatnonzero(~mask), tas[~mask])
+
             except IndexError:
                 continue
             counts = spiffile.instgrps[inst_group]['core']['clock_counts'][:]


### PR DESCRIPTION
Hi @kennybala97, 

The DMT PIP/CIP probe processing has a similar issue indicated in https://github.com/nrc-cnrc/NRC-SPIFpy/issues/4#issue-2387014353

I have fixed the issue and also fixed the issue with `nanosecond` as well. I have tested it with the synthetic data and it works fine.

Yongjie